### PR TITLE
Fixed bug on getImagePredictionList

### DIFF
--- a/lib/model.dart
+++ b/lib/model.dart
@@ -47,7 +47,7 @@ class Model {
   ///predicts image but returns the raw net output
   Future<List> getImagePredictionList(File image, int width, int height) async {
     final List prediction = await _channel.invokeListMethod("predictImage",
-        {"index": _index, "image": image, "width": width, "height": height});
+        {"index": _index, "image": image.readAsBytesSync(), "width": width, "height": height});
     return prediction;
   }
 


### PR DESCRIPTION
I'm pretty sure that this should be passed in as an bytes array