### PR TITLE
Torch 1.8.0 update and torchvision ops support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,9 @@ android {
 }
 
 dependencies{
-    implementation 'org.pytorch:pytorch_android:1.6.0'
-    implementation 'org.pytorch:pytorch_android_torchvision:1.6.0'
+    implementation 'org.pytorch:pytorch_android:1.8.0'
+    implementation 'org.pytorch:pytorch_android_torchvision:1.8.0'
+    implementation 'org.pytorch:torchvision_ops:0.9.0'
+    implementation 'com.facebook.soloader:nativeloader:0.8.0'
 }
  

--- a/android/src/main/java/io/fynn/pytorch_mobile/PyTorchMobilePlugin.java
+++ b/android/src/main/java/io/fynn/pytorch_mobile/PyTorchMobilePlugin.java
@@ -145,7 +145,7 @@ public class PyTorchMobilePlugin implements FlutterPlugin, MethodCallHandler {
       case FLOAT32:
         return Tensor.fromBlob(Convert.toFloatPrimitives(data), Convert.toPrimitives(shape));
       case FLOAT64:
-        return  Tensor.fromBlob(Convert.toDoublePrimitives(data), Convert.toDoublePrimitives(shape));
+        return  Tensor.fromBlob(Convert.toDoublePrimitives(data), Convert.toPrimitives(shape));
       case INT32:
         return Tensor.fromBlob(Convert.toIntegerPrimitives(data), Convert.toPrimitives(shape));
       case INT64:

--- a/android/src/main/java/io/fynn/pytorch_mobile/PyTorchMobilePlugin.java
+++ b/android/src/main/java/io/fynn/pytorch_mobile/PyTorchMobilePlugin.java
@@ -18,10 +18,22 @@ import org.pytorch.Module;
 import org.pytorch.Tensor;
 import org.pytorch.torchvision.TensorImageUtils;
 
+// Native Loader for torchscript support
+import com.facebook.soloader.nativeloader.NativeLoader;
+import com.facebook.soloader.nativeloader.SystemDelegate;
+
 import java.util.ArrayList;
 
 /** TorchMobilePlugin */
 public class PyTorchMobilePlugin implements FlutterPlugin, MethodCallHandler {
+  
+  static {
+    if (!NativeLoader.isInitialized()) {
+      NativeLoader.init(new SystemDelegate());
+    }
+    NativeLoader.loadLibrary("pytorch_jni");
+    NativeLoader.loadLibrary("torchvision_ops");
+  }
 
   ArrayList<Module> modules = new ArrayList<>();
 
@@ -133,7 +145,7 @@ public class PyTorchMobilePlugin implements FlutterPlugin, MethodCallHandler {
       case FLOAT32:
         return Tensor.fromBlob(Convert.toFloatPrimitives(data), Convert.toPrimitives(shape));
       case FLOAT64:
-        return  Tensor.fromBlob(Convert.toPrimitives(shape), Convert.toDoublePrimitives(data));
+        return  Tensor.fromBlob(Convert.toDoublePrimitives(data), Convert.toDoublePrimitives(shape));
       case INT32:
         return Tensor.fromBlob(Convert.toIntegerPrimitives(data), Convert.toPrimitives(shape));
       case INT64:

--- a/ios/pytorch_mobile.podspec
+++ b/ios/pytorch_mobile.podspec
@@ -21,7 +21,7 @@ A new flutter plugin project.
   s.ios.deployment_target = '12.0'
   s.static_framework = true
   s.public_header_files = 'Classes/**/*.h'
-  s.dependency 'LibTorch', '~> 1.6.0'
+  s.dependency 'LibTorch', '~> 1.8.0'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
       'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/LibTorch/install/include"'


### PR DESCRIPTION
Updated torch 1.6.0 to torch 1.8.0, and added `torchvision_ops` support for android at least (Don't have mac device).
And there was a bug here: https://github.com/fynnmaarten/flutter_pytorch_mobile/blob/3f0dcbcb560668d36828a8d7d18c21549e46c34a/android/src/main/java/io/fynn/pytorch_mobile/PyTorchMobilePlugin.java#L135-L136
where the order of `data` and `shape` was mistaken.

And I have added `torchvision_ops` support for android here, it is a very useful feature for object detection models.