### PR TITLE
iOS: leaks

### DIFF
--- a/ios/Classes/Helpers/UIImageExtension.m
+++ b/ios/Classes/Helpers/UIImageExtension.m
@@ -42,6 +42,7 @@
         normalizedBuffer[w * h * 2 + i] = (rawBytes[i * 4 + 2] / 255.0 - mean[2].floatValue) / std[2].floatValue;	
     }
     
+    free(rawBytes);
     return normalizedBuffer;
 }
 

--- a/ios/Classes/PyTorchMobilePlugin.mm
+++ b/ios/Classes/PyTorchMobilePlugin.mm
@@ -101,6 +101,8 @@ NSMutableArray *modules = [[NSMutableArray alloc] init];
             } catch (const std::exception& e) {
                 NSLog(@"PyTorchMobile: %s", e.what());
             }
+
+            free(input);
           
             break;
         }


### PR DESCRIPTION
Hi, we experienced some leaks in our iOS app, after some investigation we found two memory leaks:
- rawBytes in UIImageExtension (calloc not freed)
- normalizedBuffer in UIImageExtension (malloc not freed)

from the Profiler:
![Profiler image](https://user-images.githubusercontent.com/26308013/220028058-07e62f5b-ce8e-421f-8f77-00ab90b4a5e9.png)


In the first case, I was able to free the memory at the end of the method.
But in the second case, we return normalizedBuffer to use as the input, so I freed the input in PyTorchMobilePlugin.

Hoping for your fast response.
Maor. 